### PR TITLE
Moodle 4.5: Hook after_config

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -15,18 +15,31 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version details.
+ * Main library file for interfaces.
  *
  * @package    tool_seo
  * @copyright  2019 Andrew Madden <andrewmadden@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace tool_seo;
 
-$plugin->version = 2024111200;
-$plugin->release = 2024111200; // Match release exactly to version.
-$plugin->requires = 2024100700; // Moodle 4.5.
-$plugin->component = 'tool_seo';
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [405];     // Supports Moodle 4.1 or later.
+use core\hook\after_config;
+
+/**
+ * Hook callbacks
+ *
+ * @package    tool_seo
+ * @author     Jakob Heinemann <jakob@jakobheinemann.de>
+ */
+class hook_callbacks {
+    /**
+     * Listener for the after_config hook.
+     *
+     * overwrites page object!
+     * @param after_config $hook
+     */
+    public static function after_config(\core\hook\after_config $hook): void {
+        \tool_seo\robots::serve();
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -31,4 +31,8 @@ $callbacks = [
         'callback' => 'tool_seo\local\hook\output\before_standard_head_html_generation::callback',
         'priority' => 0,
     ],
+    [
+        'hook' => \core\hook\after_config::class,
+        'callback' => [\tool_seo\hook_callbacks::class, 'after_config'],
+    ],
 ];

--- a/lib.php
+++ b/lib.php
@@ -43,12 +43,4 @@ function tool_seo_before_standard_html_head() {
     return '';
 }
 
-/**
- * Used to serve robots.txt if not found.
- *
- * @throws \moodle_exception
- */
-function tool_seo_after_config() {
-    \tool_seo\robots::serve();
-}
 

--- a/version.php
+++ b/version.php
@@ -29,4 +29,4 @@ $plugin->release = 2024111200; // Match release exactly to version.
 $plugin->requires = 2024100700; // Moodle 4.5.
 $plugin->component = 'tool_seo';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [405];     // Supports Moodle 4.1 or later.
+$plugin->supported = [405,409];     // Supports Moodle 4.5 or later.


### PR DESCRIPTION
Moved after_config from lib.php to classes/hook_callbacks.php (new hook system)